### PR TITLE
Put issue template inside a HTML comment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 If you have a question please search or post to our Discourse site: https://discourse.julialang.org.
 We use the GitHub issue tracker for bug reports and feature requests only.
 
@@ -7,3 +8,4 @@ If you're experiencing a problem with a particular package, open an issue on tha
 package's repository instead.
 
 Thanks for contributing to the Julia project!
+-->


### PR DESCRIPTION
Currently, whenever you open an issue, you have to delete the whole issue template body. If the issue template is put inside a HTML comment, that will be required no more, while the issue template content stays the same.